### PR TITLE
fix-7[Add doc type to index-html]

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <script type="text/javascript" src="index.js"></script>


### PR DESCRIPTION
## Description
The `!DOCTYPE html` declaration is now added to the html file. This declaration is essential for ensuring that the web page is rendered in a standards-compliant manner, preventing quirks mode, and making sure browsers use the appropriate rendering mode for modern HTML documents.


## Acceptance Criteria (AC)

- [x] Doctype declared in line 1