### PR TITLE
Added content stays after refresh

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,9 @@ document.addEventListener("DOMContentLoaded", function () {
         }
         document.getElementById("input1").value = "";
     }
+
 });
+
 
 function saveTagToLocalStorage(tag) {
     let savedTags = JSON.parse(localStorage.getItem("myTags")) || [];
@@ -39,11 +41,10 @@ function saveTagToLocalStorage(tag) {
 }
 
 function uploadTagsFromLocalStorage() {
-    let savedTags = JSON.parse(localStorage.getItem("tags")) || [];
+    let savedTags = JSON.parse(localStorage.getItem("myTags")) || [];
     savedTags.forEach(tag => {
         let li = "<li>" + tag + "</li>";
         document.getElementById("list").insertAdjacentHTML("beforeend", li);
     });
 }
-
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,27 +5,45 @@ const tags = tagsW3.map(tag => tag.replace(/[<|>]/g, ""));
 
 // Wait for the DOM to be fully loaded
 document.addEventListener("DOMContentLoaded", function () {
-  // Find the form element and add a submit event listener
-  const form = document.querySelector("form");
-  form.addEventListener("submit", function (event) {
-    // on submit
-    event.preventDefault(); // Prevent the default form submission
-    submitVal(); // call our submitVal function
-  });
+    uploadTagsFromLocalStorage(); // list all tags in localStorage
 
-  function submitVal() {
-    let val = document.getElementById("input1").value;
-    // remove all white spaces and non-alphabetical characters except . ! - 
-    let regex = /[^a-zA-Z!-.]/g;
-    // change input to lower case and apply regex
-    let sanitizedVal = val.toLowerCase().replace(regex, "");
-    localStorage.setItem("val", sanitizedVal);
-    let li = "<li>" + sanitizedVal + "</li>";
-    // check if the input value is in the tags array
-    let found = tags.some(tag => tag.toLowerCase() === sanitizedVal);
-    if (found) {
-      document.getElementById("list").insertAdjacentHTML("beforeend", li);
+    // Find the form element and add a submit event listener
+    const form = document.querySelector("form");
+    form.addEventListener("submit", function (event) {
+        // on submit
+        event.preventDefault(); // Prevent the default form submission
+        submitVal(); // call our submitVal function
+    });
+
+    function submitVal() {
+        let val = document.getElementById("input1").value;
+        // remove all white spaces and non-alphabetical characters except . ! - 
+        let regex = /[^a-zA-Z!-.]/g;
+        // change input to lower case and apply regex
+        let sanitizedVal = val.toLowerCase().replace(regex, "");
+        let li = "<li>" + sanitizedVal + "</li>";
+        // check if the input value is in the tags array
+        let found = tags.some(tag => tag.toLowerCase() === sanitizedVal);
+        if (found) {
+            document.getElementById("list").insertAdjacentHTML("beforeend", li);
+            saveTagToLocalStorage(sanitizedVal); // Save tag to localStorage
+        }
+        document.getElementById("input1").value = "";
     }
-    document.getElementById("input1").value = "";
-  }
 });
+
+function saveTagToLocalStorage(tag) {
+    let savedTags = JSON.parse(localStorage.getItem("myTags")) || [];
+    savedTags.push(tag);
+    localStorage.setItem("myTags", JSON.stringify(savedTags));
+}
+
+function uploadTagsFromLocalStorage() {
+    let savedTags = JSON.parse(localStorage.getItem("tags")) || [];
+    savedTags.forEach(tag => {
+        let li = "<li>" + tag + "</li>";
+        document.getElementById("list").insertAdjacentHTML("beforeend", li);
+    });
+}
+
+


### PR DESCRIPTION
## Description
As a user I want the added input to be shown in the list even when refreshing the page.

I achieved this goal by using `localStorage`. I added two functions in order for each tag added to be saved and uploaded respectively from local storage.

**Notes**
1. Using `localStorage` has also the added benefit of preserving a user's list between sessions. Originally, we used `localStorage` to save, but not retrieve, the last tag added.
2. Right now, the code is not perfectly DRY in respect to adding a tag to the list and retrieving it from local storage. I will suggest a separate issue to achieve this since it might involve refactoring code outside the scope of this issue.
 
## Related Issue
Closes #10

## Acceptance Criteria (AC)

 - [x] When adding a new tag in the list, the tag is still visible in the list after refreshing the page

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :sparkles: Enhancement             |

## Screenshots

Adding some tags:
![image](https://github.com/YurisCodingClub/html-tag-quiz/assets/115652409/c900ae62-c2bc-4caa-9846-be42075410e9)

The list is preserved after refreshing the page:
![image](https://github.com/YurisCodingClub/html-tag-quiz/assets/115652409/7f91e0e4-8f76-4b59-a0c1-e2c3c5c19295)

## Testing Steps / QA Criteria
 
To test, add at least one item to the list. Refreshing the page should preserve the list.
