### PR TITLE
Clear input field 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,8 +37,8 @@ document.addEventListener("DOMContentLoaded", function () {
     if (found && !checkDuplicate) {
         document.getElementById("list").insertAdjacentHTML("beforeend", li);
         saveTagToLocalStorage(sanitizedVal); // Save tag to localStorage
+        document.getElementById("input").value = "";
     }
-    document.getElementById("input").value = "";
   }
 });
 


### PR DESCRIPTION
### Description
When hitting enter and the tag was not in the list, the `input` field gets cleared up. But if the tag is already in the list, the content stays to show the user that it was not added to the list.

### Changes
I moved the functionality inside the if statement (switch line 40 and 41), so it only gets called when a new tag is added to the list.

### Related
closes #22 

### 💡 Thoughts
Showing that the tag is already in the list could maybe be generated in a better way. For now, the user does not know if the tag is already in the list or if the tag even exists (e.g. typo). Or is this already too much of a hint? The outline could be more intense (or/with micro animation), a "error" message below/beneath could be shown..